### PR TITLE
Preserve newlines if they exist at the end of templates

### DIFF
--- a/fastfood/templating.py
+++ b/fastfood/templating.py
@@ -66,4 +66,6 @@ def render_templates_generator(*files, **template_map):
                     msg, err.lineno, filename=os.path.basename(path))
 
             result = template.render(**template_map)
+            if open(path).read().endswith('\n'):
+                result+='\n'
             yield path, result

--- a/fastfood/templating.py
+++ b/fastfood/templating.py
@@ -67,5 +67,5 @@ def render_templates_generator(*files, **template_map):
 
             result = template.render(**template_map)
             if open(path).read().endswith('\n'):
-                result+='\n'
+                result += '\n'
             yield path, result

--- a/fastfood/templating.py
+++ b/fastfood/templating.py
@@ -66,6 +66,6 @@ def render_templates_generator(*files, **template_map):
                     msg, err.lineno, filename=os.path.basename(path))
 
             result = template.render(**template_map)
-            if open(path).read().endswith('\n'):
+            if not result.endswith('\n'):
                 result += '\n'
             yield path, result


### PR DESCRIPTION
This fixes workarounds like https://github.com/rackerlabs/fastfood-templatepack/blob/master/base/metadata.rb#L14-L16