### PR TITLE
simplify, FileWrapper, Berksfile and tests

### DIFF
--- a/fastfood/book.py
+++ b/fastfood/book.py
@@ -105,6 +105,8 @@ class CookBook(object):
 
 class Berksfile(object):
 
+    """Wrapper for a Berksfile."""
+
     berks_options = [
         'branch',
         'git',
@@ -175,6 +177,7 @@ class Berksfile(object):
                     datamap[key].append(utils.ruby_strip(value))
                 elif key:
                     datamap[key] = utils.ruby_strip(value)
+        self.seek(0)
         return datamap
 
     def merge(self, other):
@@ -188,7 +191,7 @@ class Berksfile(object):
         berksfile_writelines = []
         # compare and gather cookbook dependencies
         for ckbkname, meta in new.get('cookbook', {}).items():
-            if ckbkname in current.get('cookbook'):
+            if ckbkname in current.get('cookbook', {}):
                 print '%s already has %s' % (self, ckbkname)
                 continue
             line = "cookbook '%s'" % ckbkname
@@ -202,6 +205,8 @@ class Berksfile(object):
 
         # compare and gather 'source' requirements
         for source in new.get('source', []):
+            if source in current.get('source', []):
+                continue
             line = "source '%s'" % source
             berksfile_writelines.append("%s\n" % line)
         return self.write_statements(berksfile_writelines)

--- a/fastfood/book.py
+++ b/fastfood/book.py
@@ -156,6 +156,7 @@ class Berksfile(utils.FileWrapper):
 
     def parse(self):
         """Parse this Berksfile into a dict."""
+        self.flush()
         self.seek(0)
         data = utils.ruby_lines(self.readlines())
         data = [tuple(j.strip() for j in line.split(None, 1))

--- a/fastfood/book.py
+++ b/fastfood/book.py
@@ -40,8 +40,7 @@ class CookBook(object):
     def metadata(self):
         """Return dict representation of this cookbook's metadata.rb ."""
         if not self._metadata:
-            with open(self.metadata_path) as meta:
-                self._metadata = MetadataRb(meta)
+            self._metadata = MetadataRb(open(self.metadata_path, 'r+'))
         return self._metadata
 
     @property
@@ -51,8 +50,7 @@ class CookBook(object):
             if not os.path.isfile(self.berks_path):
                 raise ValueError("No Berksfile found at %s"
                                  % self.berks_path)
-            with open(self.berks_path) as berks:
-                self._berksfile = Berksfile(berks)
+            self._berksfile = Berksfile(open(self.berks_path, 'r+'))
         return self._berksfile
 
 

--- a/fastfood/food.py
+++ b/fastfood/food.py
@@ -33,6 +33,11 @@ LOG = logging.getLogger(__name__)
 
 def build_cookbook(build_config, templatepack, cookbooks_home,
                    cookbook_path=None, force=False):
+    """Build a cookbook from a fastfood.json file.
+
+    Can build on an existing cookbook, otherwise this will
+    create a new cookbook for you based on your templatepack.
+    """
 
     with open(build_config) as cfg:
         cfg = json.load(cfg)
@@ -72,7 +77,6 @@ def update_cookbook(cookbook, templatepack, stencilset_name, **options):
 
     force = options.get('force', False)
     tmppack = pack.TemplatePack(templatepack)
-    existing_deps = cookbook.metadata.to_dict().get('depends', {}).keys()
     stencilset = tmppack.load_stencil_set(stencilset_name)
 
     if 'stencil' not in options:

--- a/fastfood/shell.py
+++ b/fastfood/shell.py
@@ -26,6 +26,7 @@ import threading
 import urllib2
 
 import fastfood
+from fastfood import book
 from fastfood import food
 from fastfood import pack
 

--- a/fastfood/shell.py
+++ b/fastfood/shell.py
@@ -38,8 +38,9 @@ CHECK = '\xe2\x9c\x85'
 
 def _fastfood_gen(args):
 
+    cookbook = book.CookBook(args.cookbook)
     return food.update_cookbook(
-        args.cookbook, args.template_pack, args.stencil_set,
+        cookbook, args.template_pack, args.stencil_set,
         force=args.force, **args.options)
 
 
@@ -58,9 +59,17 @@ def _fastfood_new(args):
 
 def _fastfood_build(args):
 
-    return food.build_cookbook(
+    written_files, cookbook = food.build_cookbook(
         args.config_file, args.template_pack,
         args.cookbooks, cookbook_path=args.cookbook)
+
+    if len(written_files) > 0:
+        print("%s: %s files written" % (cookbook,
+                                        len(written_files)))
+    else:
+        print("%s up to date" % cookbook)
+
+    return written_files, cookbook
 
 
 def _fastfood_list(args):

--- a/fastfood/utils.py
+++ b/fastfood/utils.py
@@ -160,4 +160,5 @@ class FileWrapper(object):
 
         if new_content_lines != original_content_lines:
             self.seek(0)
-            return self.writelines(new_content_lines)
+            self.writelines(new_content_lines)
+            self.flush()

--- a/tests/functional/test_commands.py
+++ b/tests/functional/test_commands.py
@@ -1,0 +1,70 @@
+"""Functional tests for command line use."""
+
+import errno
+import os
+import shutil
+import tempfile
+import unittest
+
+from fastfood import pack
+
+TEST_TEMPLATEPACK = os.path.abspath(
+    os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                 os.path.pardir, 'test_templatepack'))
+assert os.path.isdir(TEST_TEMPLATEPACK), "Test templatepack not found."
+
+
+class MockArgs(object):
+
+    def __init__(self, **args):
+        self.__dict__['_args'] = args
+
+    def __setattr__(self, key, val):
+        self._args[key] = val
+
+    def __getattr__(self, attr):
+        return self._args[attr]
+
+    def __repr__(self):
+        return '<MockArgs %s>' % repr(self._args)
+
+
+class TestFastfoodCommands(unittest.TestCase):
+
+    def create_tempdir(self, **kw):
+        kw.setdefault('prefix', '%s-' % __file__)
+        new = tempfile.mkdtemp(**kw)
+        self.tempdirs.append(new)
+        return new
+
+    def setUp(self):
+
+        self.tempdirs = []
+        self.templatepack_path = TEST_TEMPLATEPACK
+        self.pack = pack.TemplatePack(self.templatepack_path)
+        # make a separate ref in case something modifies the instance attr
+        self.cookbooks_path = self._tmpcbd = self.create_tempdir(
+            suffix='.cookbooks_dir')
+
+        cli_args = {
+            'template_pack': self.templatepack_path,
+            'cookbooks': self.cookbooks_path,
+            'cookbook': None,
+            'cookbook_name': None,
+            'force': None,
+            'options': None,  # stencil options
+            'config_file': None,  # for `fastfood build`
+        }
+        self.args = MockArgs(**cli_args)
+
+    def tearDown(self):
+        for tmpd in self.tempdirs:
+            try:
+                shutil.rmtree(tmpd)
+            except OSError as exc:
+                if exc.errno != errno.ENOENT:
+                    raise
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/functional/test_fastfood_build_command.py
+++ b/tests/functional/test_fastfood_build_command.py
@@ -1,0 +1,55 @@
+"""Functional tests for command line use."""
+
+import tempfile
+import unittest
+
+from fastfood import shell
+
+import test_commands
+
+BUILD_CONFIG = """
+{
+  "name": "test_build_cookbook",
+  "stencils": [
+    {
+      "stencil_set": "utility",
+      "stencil": "default",
+      "openfor": "test_build_cookbook"
+    },
+    {
+      "stencil_set": "nodejs"
+    },
+    {
+      "stencil_set": "newrelic"
+    },
+    {
+      "stencil_set": "apache"
+    }
+  ]
+}
+""".strip()
+
+class TestFastfoodNewCommand(test_commands.TestFastfoodCommands):
+
+    def test_fastfood_build_from_scratch(self):
+
+        build_config_file = tempfile.NamedTemporaryFile()
+        build_config_file.write(BUILD_CONFIG)
+        build_config_file.seek(0)
+
+        self.args.config_file = build_config_file.name
+        _, cookbook = shell._fastfood_build(self.args)
+        self.assertEqual(cookbook.name, 'test_build_cookbook')
+        metadata = cookbook.metadata.to_dict()
+        self.assertIn('sudo', metadata['depends'])
+        self.assertIn('users', metadata['depends'])
+        self.assertIn('rackops_rolebook', metadata['depends'])
+        self.assertIn('nodejs', metadata['depends'])
+        self.assertIn('newrelic', metadata['depends'])
+        self.assertIn('rackspace_iptables', metadata['depends'])
+        self.assertIn('ulimit', metadata['depends'])
+        berks = cookbook.berksfile.to_dict()
+        self.assertIn('nodejs', berks['cookbook'])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/functional/test_fastfood_build_command.py
+++ b/tests/functional/test_fastfood_build_command.py
@@ -29,6 +29,7 @@ BUILD_CONFIG = """
 }
 """.strip()
 
+
 class TestFastfoodNewCommand(test_commands.TestFastfoodCommands):
 
     def test_fastfood_build_from_scratch(self):

--- a/tests/functional/test_fastfood_new_command.py
+++ b/tests/functional/test_fastfood_new_command.py
@@ -1,62 +1,16 @@
 """Functional tests for command line use."""
 
-import errno
 import os
 import random
-import shutil
 import string
-import tempfile
 import unittest
 
-from fastfood import pack
 from fastfood import shell
 
-TEST_TEMPLATEPACK = os.path.abspath(
-    os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                 os.path.pardir, 'test_templatepack'))
-assert os.path.isdir(TEST_TEMPLATEPACK), "Test templatepack not found."
+import test_commands
 
 
-class MockArgs(object):
-
-    def __init__(self, **args):
-        self._args = args
-        for key, value in args.iteritems():
-            setattr(self, key, value)
-
-    def __repr__(self):
-        return repr(self._args)
-
-
-class TestFastfoodCommands(unittest.TestCase):
-
-    def setUp(self):
-
-        self.templatepack_path = TEST_TEMPLATEPACK
-        self.pack = pack.TemplatePack(self.templatepack_path)
-        # make a separate ref in case something modifies the instance attr
-        self.cookbooks_path = self._tmpcbd = tempfile.mkdtemp(
-            prefix='%s.' % __file__, suffix='.cookbooks_dir')
-        cli_args = {
-            'template_pack': self.templatepack_path,
-            'cookbooks': self.cookbooks_path,
-            'cookbook': None,
-            'cookbook_name': None,
-            'force': None,
-            'options': None,  # stencil options
-            'config_file': None,  # for `fastfood build`
-        }
-        self.args = MockArgs(**cli_args)
-
-    def tearDown(self):
-        try:
-            shutil.rmtree(self._tmpcbd)
-        except OSError as exc:
-            if exc.errno != errno.ENOENT:
-                raise
-
-
-class TestFastfoodNewCommand(TestFastfoodCommands):
+class TestFastfoodNewCommand(test_commands.TestFastfoodCommands):
 
     def test_fastfood_new(self):
 

--- a/tests/test_berks.py
+++ b/tests/test_berks.py
@@ -1,0 +1,120 @@
+"""Berksfile related tests."""
+
+import unittest
+
+FIRST_BERKS = """
+source 'https://supermarket.getchef.com'
+
+cookbook 'newrelic_plugins', git: 'git@github.com:rackspace-cookbooks/newrelic_plugins_chef.git'
+cookbook 'disable_ipv6', path: 'test/fixtures/cookbooks/disable_ipv6'
+cookbook 'wrapper', path: 'test/fixtures/cookbooks/wrapper'
+cookbook 'apt'
+
+# until https://github.com/elasticsearch/cookbook-elasticsearch/pull/230
+cookbook 'elasticsearch', '~> 0.3', git:'git@github.com:racker/cookbook-elasticsearch.git'
+
+# until https://github.com/lusis/chef-logstash/pull/336 & 394
+cookbook 'logstash', git:'git@github.com:racker/chef-logstash.git'
+
+metadata
+"""
+
+SECOND_BERKS = """
+source "https://supermarket.chef.io"
+
+metadata
+
+cookbook 'cron', git: 'git@github.com:rackspace-cookbooks/cron.git'
+# until https://github.com/elastic/cookbook-elasticsearch/pull/230
+
+cookbook 'disable_ipv6', path: 'test/fixtures/cookbooks/disable_ipv6'
+cookbook 'wrapper', path: 'test/fixtures/cookbooks/wrapper'
+cookbook 'yum'
+
+cookbook 'fake', '~> 9.1'
+"""
+
+import copy
+
+from fastfood import book
+
+class TestBerks(unittest.TestCase):
+
+    def test_merge(self):
+
+        fb = book.Berksfile.from_string(FIRST_BERKS)
+        before = copy.deepcopy(fb.to_dict())
+        self.assertIn('cookbook', before)
+        self.assertIsInstance(before['cookbook'], dict)
+        self.assertNotIn('cron', before['cookbook'])
+        self.assertNotIn('fake', before['cookbook'])
+        self.assertNotIn('yum', before['cookbook'])
+        self.assertIn('source', before)
+        self.assertIsInstance(before['source'], list)
+        self.assertNotIn('https://supermarket.chef.io', before['source'])
+
+        sb = book.Berksfile.from_string(SECOND_BERKS)
+        fb.merge(sb)
+        after = fb.to_dict()
+
+        self.assertIn('cron', after['cookbook'])
+        self.assertIn('fake', after['cookbook'])
+        self.assertIn('yum', after['cookbook'])
+        self.assertIn('source', after)
+        self.assertEqual(after['source'],
+                ['https://supermarket.getchef.com',
+                 'https://supermarket.chef.io'])
+        self.assertEqual(after['cookbook']['fake']['constraint'],
+                        '~> 9.1')
+        self.assertEqual(after['cookbook']['cron']['git'],
+                         'git@github.com:rackspace-cookbooks/cron.git')
+
+    def test_berks_to_dict(self):
+
+        fb = book.Berksfile.from_string(FIRST_BERKS)
+        self.assertIsInstance(fb, book.Berksfile)
+        fbd = fb.to_dict()
+        self.assertIsInstance(fbd, dict)
+        self.assertIn('cookbook', fbd)
+        self.assertIsInstance(fbd['cookbook'], dict)
+        self.assertIn('source', fbd)
+        self.assertIsInstance(fbd['source'], list)
+        self.assertIn('https://supermarket.getchef.com', fbd['source'])
+        self.assertIn('metadata', fbd)
+        self.assertTrue(fbd['metadata'] is True)
+
+        expects = [
+            'newrelic_plugins',
+            'disable_ipv6',
+            'elasticsearch',
+            'wrapper',
+            'apt',
+            'logstash',
+        ]
+        self.assertEqual(len(fbd['cookbook']), len(expects))
+        for cb in expects:
+            self.assertIn(cb, fbd['cookbook'])
+
+        self.assertEqual(
+            fbd['cookbook']['newrelic_plugins']['git'],
+            'git@github.com:rackspace-cookbooks/newrelic_plugins_chef.git')
+        self.assertEqual(
+            fbd['cookbook']['disable_ipv6']['path'],
+            'test/fixtures/cookbooks/disable_ipv6')
+        self.assertEqual(
+            fbd['cookbook']['wrapper']['path'],
+            'test/fixtures/cookbooks/wrapper')
+        self.assertEqual(fbd['cookbook']['apt'], {})
+        self.assertEqual(
+            fbd['cookbook']['elasticsearch']['constraint'],
+            '~> 0.3')
+        self.assertEqual(
+            fbd['cookbook']['elasticsearch']['git'],
+            'git@github.com:racker/cookbook-elasticsearch.git')
+        self.assertEqual(
+            fbd['cookbook']['logstash']['git'],
+            'git@github.com:racker/chef-logstash.git')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_templatepack/manifest.json
+++ b/tests/test_templatepack/manifest.json
@@ -7,6 +7,12 @@
     },
     "newrelic": {
       "help": "Creates a newrelic recipe"
+    },
+    "apache": {
+      "help": "Creates a recipe for installing and tuning Apache2.4"
+    },
+    "nodejs": {
+      "help": "Installs NodeJS and provides an NPM LWRP"
     }
   },
   "base": {

--- a/tests/test_templatepack/stencils/apache/manifest.json
+++ b/tests/test_templatepack/stencils/apache/manifest.json
@@ -1,0 +1,28 @@
+{
+  "id": "apache",
+  "api": 1,
+  "default_stencil": "apache",
+  "dependencies": {
+    "rackspace_iptables": {},
+    "ulimit": {}
+  },
+  "options": {
+    "name": {
+      "help": "Name of the recipe to create",
+      "default": "_apache"
+    }
+  },
+  "stencils": {
+    "apache": {
+      "files": {
+        "recipes/<NAME>.rb": "recipes/_apache.rb.jinja2",
+        "templates/default/apache/apache2.conf.erb": "templates/default/apache2.conf.erb",
+        "templates/default/apache/mpm_event.conf.erb": "templates/default/mpm_event.conf.erb",
+        "templates/default/apache/ports.conf.erb": "templates/default/ports.conf.erb",
+        "test/integration/default/serverspec/<NAME>_spec.rb": "test/integration/default/serverspec/apache_spec.rb"
+      },
+      "options": {
+      }
+    }
+  }
+}

--- a/tests/test_templatepack/stencils/apache/recipes/_apache.rb.jinja2
+++ b/tests/test_templatepack/stencils/apache/recipes/_apache.rb.jinja2
@@ -1,0 +1,95 @@
+# Install and configure Apache2
+
+# Base webserver user on distro.
+node.default['apache']['user'] = 'www-data'
+
+# mostly used to simply run an "apt-get update" on boot, etc.
+case node['platform']
+when 'debian', 'ubuntu'
+  # Use Apache 2.4.9, which includes the UDS patch for Unix Socket Support
+  apt_repository 'apache2' do
+    uri 'ppa:ondrej/apache2'
+    distribution node['lsb']['codename']
+    key 'E5267A6C'
+    keyserver 'hkp://keyserver.ubuntu.com:80'
+    action :add
+  end
+  package 'apache2' do
+    action [:upgrade, :install]
+  end
+  package 'libapache2-mod-fastcgi' do
+    action [:upgrade, :install]
+  end
+when 'redhat', 'centos', 'fedora', 'amazon', 'scientific'
+  # Sorry, we don't support centos just yet. Stay tuned!
+  node.default['apache']['user'] = 'apache2'
+end
+
+apache2_modules = %w(remoteip proxy_fcgi headers rewrite mpm_event expires)
+# Disable mod_php and the prefork MPM since we'll be using EVENT
+disabled_apache2_modules = ['mpm_prefork', 'php5']
+
+# Apache2.conf
+template '/etc/apache2/apache2.conf' do
+  source 'apache/apache2.conf.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  notifies :restart, 'service[apache2]'
+end
+
+# ports.conf
+template '/etc/apache2/ports.conf' do
+  source 'apache/ports.conf.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  variables(
+    my_ip: node['address_map']['my_ip']
+  )
+  notifies :restart, 'service[apache2]'
+end
+
+# Disable the default site
+file '/etc/apache2/sites-enabled/000-default.conf' do
+  action :delete
+  notifies :restart, 'service[apache2]'
+end
+
+# Disabled Apache2 modules
+disabled_apache2_modules.each do |mod|
+  execute "disable apache module #{mod}" do
+    command "a2dismod #{mod}"
+    only_if { File.exist?("/etc/apache2/mods-enabled/#{mod}.load") }
+    notifies :restart, 'service[apache2]'
+  end
+end
+# Apache2 modules
+apache2_modules.each do |mod|
+  execute "enable apache module #{mod}" do
+    command "a2enmod #{mod}"
+    only_if { !File.exist?("/etc/apache2/mods-enabled/#{mod}.load") }
+    notifies :restart, 'service[apache2]'
+  end
+end
+
+template '/etc/apache2/mods-available/mpm_event.conf' do
+  source 'apache/mpm_event.conf.erb'
+  notifies :restart, 'service[apache2]'
+  mode '0644'
+  owner 'root'
+  group 'root'
+end
+
+add_iptables_rule('INPUT', '-p tcp --dport 80 -j ACCEPT', 50, 'allow HTTP')
+
+user_ulimit node['apache']['user'] do
+  filehandle_limit 8192
+end
+
+# Apache2 service
+service 'apache2' do
+  service_name 'apache2'
+  action [:enable, :start]
+  supports restart: true, reload: true, status: true
+end

--- a/tests/test_templatepack/stencils/apache/templates/default/apache2.conf.erb
+++ b/tests/test_templatepack/stencils/apache/templates/default/apache2.conf.erb
@@ -1,0 +1,229 @@
+# This is the main Apache server configuration file.  It contains the
+# configuration directives that give the server its instructions.
+# See http://httpd.apache.org/docs/2.4/ for detailed information about
+# the directives and /usr/share/doc/apache2/README.Debian about Debian specific
+# hints.
+#
+#
+# Summary of how the Apache 2 configuration works in Debian:
+# The Apache 2 web server configuration in Debian is quite different to
+# upstream's suggested way to configure the web server. This is because Debian's
+# default Apache2 installation attempts to make adding and removing modules,
+# virtual hosts, and extra configuration directives as flexible as possible, in
+# order to make automating the changes and administering the server as easy as
+# possible.
+
+# It is split into several files forming the configuration hierarchy outlined
+# below, all located in the /etc/apache2/ directory:
+#
+#	/etc/apache2/
+#	|-- apache2.conf
+#	|	`--  ports.conf
+#	|-- mods-enabled
+#	|	|-- *.load
+#	|	`-- *.conf
+#	|-- conf-enabled
+#	|	`-- *.conf
+# 	`-- sites-enabled
+#	 	`-- *.conf
+#
+#
+# * apache2.conf is the main configuration file (this file). It puts the pieces
+#   together by including all remaining configuration files when starting up the
+#   web server.
+#
+# * ports.conf is always included from the main configuration file. It is
+#   supposed to determine listening ports for incoming connections which can be
+#   customized anytime.
+#
+# * Configuration files in the mods-enabled/, conf-enabled/ and sites-enabled/
+#   directories contain particular configuration snippets which manage modules,
+#   global configuration fragments, or virtual host configurations,
+#   respectively.
+#
+#   They are activated by symlinking available configuration files from their
+#   respective *-available/ counterparts. These should be managed by using our
+#   helpers a2enmod/a2dismod, a2ensite/a2dissite and a2enconf/a2disconf. See
+#   their respective man pages for detailed information.
+#
+# * The binary is called apache2. Due to the use of environment variables, in
+#   the default configuration, apache2 needs to be started/stopped with
+#   /etc/init.d/apache2 or apache2ctl. Calling /usr/bin/apache2 directly will not
+#   work with the default configuration.
+
+
+# Global configuration
+#
+
+#
+# ServerRoot: The top of the directory tree under which the server's
+# configuration, error, and log files are kept.
+#
+# NOTE!  If you intend to place this on an NFS (or otherwise network)
+# mounted filesystem then please read the Mutex documentation (available
+# at <URL:http://httpd.apache.org/docs/2.4/mod/core.html#mutex>);
+# you will save yourself a lot of trouble.
+#
+# Do NOT add a slash at the end of the directory path.
+#
+#ServerRoot "/etc/apache2"
+
+#
+# The accept serialization lock file MUST BE STORED ON A LOCAL DISK.
+#
+Mutex file:${APACHE_LOCK_DIR} default
+
+#
+# PidFile: The file in which the server should record its process
+# identification number when it starts.
+# This needs to be set in /etc/apache2/envvars
+#
+PidFile ${APACHE_PID_FILE}
+
+#
+# Timeout: The number of seconds before receives and sends time out.
+#
+Timeout 60
+
+#
+# KeepAlive: Whether or not to allow persistent connections (more than
+# one request per connection). Set to "Off" to deactivate.
+#
+KeepAlive On
+
+#
+# MaxKeepAliveRequests: The maximum number of requests to allow
+# during a persistent connection. Set to 0 to allow an unlimited amount.
+# We recommend you leave this number high, for maximum performance.
+#
+MaxKeepAliveRequests 100
+
+#
+# KeepAliveTimeout: Number of seconds to wait for the next request from the
+# same client on the same connection.
+#
+KeepAliveTimeout 5
+
+
+# These need to be set in /etc/apache2/envvars
+User ${APACHE_RUN_USER}
+Group ${APACHE_RUN_GROUP}
+
+#
+# HostnameLookups: Log the names of clients or just their IP addresses
+# e.g., www.apache.org (on) or 204.62.129.132 (off).
+# The default is off because it'd be overall better for the net if people
+# had to knowingly turn this feature on, since enabling it means that
+# each client request will result in AT LEAST one lookup request to the
+# nameserver.
+#
+HostnameLookups Off
+
+# ErrorLog: The location of the error log file.
+# If you do not specify an ErrorLog directive within a <VirtualHost>
+# container, error messages relating to that virtual host will be
+# logged here.  If you *do* define an error logfile for a <VirtualHost>
+# container, that host's errors will be logged there and not here.
+#
+ErrorLog ${APACHE_LOG_DIR}/error.log
+
+#
+# LogLevel: Control the severity of messages logged to the error_log.
+# Available values: trace8, ..., trace1, debug, info, notice, warn,
+# error, crit, alert, emerg.
+# It is also possible to configure the log level for particular modules, e.g.
+# "LogLevel info ssl:warn"
+#
+
+<% if node.chef_environment == 'dev' %>
+LogLevel info
+<% else %>
+LogLevel error
+<% end %>
+
+# Include module configuration:
+IncludeOptional mods-enabled/*.load
+IncludeOptional mods-enabled/*.conf
+
+# Include list of ports to listen on
+Include ports.conf
+
+
+# Sets the default security model of the Apache2 HTTPD server. It does
+# not allow access to the root filesystem outside of /usr/share and /var/www.
+# The former is used by web applications packaged in Debian,
+# the latter may be used for local directories served by the web server. If
+# your system is serving content from a sub-directory in /srv you must allow
+# access here, or in any related virtual host.
+<Directory />
+	Options FollowSymLinks
+	AllowOverride None
+	Require all denied
+</Directory>
+
+<Directory /usr/share>
+	AllowOverride None
+	Require all granted
+</Directory>
+
+<Directory /var/www/>
+	Options Indexes FollowSymLinks
+	AllowOverride None
+	Require all granted
+</Directory>
+
+#<Directory /srv/>
+#	Options Indexes FollowSymLinks
+#	AllowOverride None
+#	Require all granted
+#</Directory>
+
+
+
+
+# AccessFileName: The name of the file to look for in each directory
+# for additional configuration directives.  See also the AllowOverride
+# directive.
+#
+AccessFileName .htaccess
+
+#
+# The following lines prevent .htaccess and .htpasswd files from being
+# viewed by Web clients.
+#
+<FilesMatch "^\.ht">
+	Require all denied
+</FilesMatch>
+
+
+#
+# The following directives define some format nicknames for use with
+# a CustomLog directive.
+#
+# These deviate from the Common Log Format definitions in that they use %O
+# (the actual bytes sent including headers) instead of %b (the size of the
+# requested file), because the latter makes it impossible to detect partial
+# requests.
+#
+# Note that the use of %{X-Forwarded-For}i instead of %h is not recommended.
+# Use mod_remoteip instead.
+#
+LogFormat "%v:%p %h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" vhost_combined
+LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" combined
+LogFormat "%h %l %u %t \"%r\" %>s %O" common
+LogFormat "%{Referer}i -> %U" referer
+LogFormat "%{User-agent}i" agent
+
+# Include of directories ignores editors' and dpkg's backup files,
+# see README.Debian for details.
+
+# Include generic snippets of statements
+IncludeOptional conf-enabled/*.conf
+
+# Include the virtual host configurations:
+IncludeOptional sites-enabled/*.conf
+
+RemoteIPHeader X-Forwarded-For
+RemoteIPInternalProxy 127.0.0.1/8
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/tests/test_templatepack/stencils/apache/templates/default/mpm_event.conf.erb
+++ b/tests/test_templatepack/stencils/apache/templates/default/mpm_event.conf.erb
@@ -1,0 +1,20 @@
+# event MPM
+# StartServers: initial number of server processes to start
+# MinSpareThreads: minimum number of worker threads which are kept spare
+# MaxSpareThreads: maximum number of worker threads which are kept spare
+# ThreadsPerChild: constant number of worker threads in each server process
+# MaxRequestWorkers: maximum number of worker threads
+# MaxConnectionsPerChild: maximum number of requests a server process serves
+<IfModule mpm_event_module>
+  StartServers             10
+  MinSpareThreads          50
+  MaxSpareThreads          100
+  ThreadLimit              128
+  ThreadsPerChild          50
+  MaxRequestWorkers        200
+  MaxConnectionsPerChild   0
+
+  ServerLimit              200
+</IfModule>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/tests/test_templatepack/stencils/apache/templates/default/ports.conf.erb
+++ b/tests/test_templatepack/stencils/apache/templates/default/ports.conf.erb
@@ -1,0 +1,15 @@
+# If you just change the port or add more ports here, you will likely also
+# have to change the VirtualHost statement in
+# /etc/apache2/sites-enabled/000-default.conf
+
+Listen <%= @my_ip %>:80
+
+<IfModule ssl_module>
+	Listen <%= @my_ip %>:443
+</IfModule>
+
+<IfModule mod_gnutls.c>
+	Listen <%= @my_ip %>:443
+</IfModule>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/tests/test_templatepack/stencils/nodejs/manifest.json
+++ b/tests/test_templatepack/stencils/nodejs/manifest.json
@@ -1,0 +1,29 @@
+{
+  "id": "nodejs",
+  "api": 1,
+  "default_stencil": "nodejs",
+  "dependencies": {
+    "nodejs": {}
+  },
+  "berks_dependencies": {
+    "nodejs": {
+      "git": "https://github.com/erulabs/nodejs"
+    }
+  },
+  "options": {
+    "name": {
+      "help": "Name of the recipe to create",
+      "default": "_nodejs"
+    }
+  },
+  "stencils": {
+    "nodejs": {
+      "files": {
+        "recipes/<NAME>.rb": "recipes/_nodejs.rb",
+        "test/integration/default/serverspec/<NAME>_spec.rb": "test/integration/default/serverspec/nodejs_spec.rb"
+      },
+      "options": {
+      }
+    }
+  }
+}

--- a/tests/test_templatepack/stencils/nodejs/recipes/_nodejs.rb
+++ b/tests/test_templatepack/stencils/nodejs/recipes/_nodejs.rb
@@ -1,0 +1,9 @@
+#
+# Cookbook Name:: |{ cookbook['name'] }|
+# Recipe :: |{ options['name'] }|
+#
+# Copyright |{ cookbook['year'] }|, Rackspace
+#
+
+# see https://github.com/erulabs/nodejs for usage
+include_recipe 'nodejs'

--- a/tests/test_templatepack/stencils/nodejs/test/integration/default/serverspec/nodejs_spec.rb
+++ b/tests/test_templatepack/stencils/nodejs/test/integration/default/serverspec/nodejs_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe file('/usr/local/bin/node') do
+  it { should be_file }
+end
+
+describe file('/usr/local/bin/npm') do
+  it { should be_file }
+end
+
+describe command('echo "console.log(\"functional test\");" | node') do
+  its(:stdout) { should match(/functional test/) }
+end


### PR DESCRIPTION

Berksfile and MetadataRb are now their own instances and share the same code in FileWrapper (`write_statements()`) for neatly writing new lines into them. 

#### todo

- [x] Get the MetadataRb implementation caught up to Berksfile (needs from_dict(), merge(), etc.)
- [x] Write  e2e and deeper functional tests


side note: Pays back some technical debt from the first week of writing. 
