### PR TITLE
Add partial templates and overwriting of templates

### DIFF
--- a/tests/functional/test_fastfood_build_command.py
+++ b/tests/functional/test_fastfood_build_command.py
@@ -70,6 +70,9 @@ class TestFastfoodBuildCommand(test_commands.TestFastfoodCommands):
         kitchen_yml = os.path.join(cookbook.path, '.kitchen.yml')
         self.assertFileContains(kitchen_yml, 'test_build_cookbook::default')
 
+        # it should also contain a partial template from the apache stencil
+        self.assertFileContains(kitchen_yml, 'test_build_cookbook::_apache')
+
         default_rb = os.path.join(cookbook.path, 'recipes', 'default.rb')
         current_year = date.today().year
         self.assertFileContains(default_rb,
@@ -79,6 +82,12 @@ class TestFastfoodBuildCommand(test_commands.TestFastfoodCommands):
 
         newrelic_rb = os.path.join(cookbook.path, 'recipes', 'newrelic.rb')
         self.assertTrue(os.path.isfile(newrelic_rb))
+
+        # verify that multiple_stencils.txt was overwritten with last stencil
+        # that appeared in ordered array in tests/functional/fastfood.json
+        multiple_stencils_txt = os.path.join(cookbook.path,
+                                             'multiple_stencils.txt')
+        self.assertFileContains(multiple_stencils_txt, 'apache stencil')
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_templatepack/stencils/apache/.kitchen.yml.jinja2
+++ b/tests/test_templatepack/stencils/apache/.kitchen.yml.jinja2
@@ -1,0 +1,4 @@
+
+  - name: apache
+    run_list:
+      - recipe[|{ cookbook['name'] }|::|{ options['name'] }|]

--- a/tests/test_templatepack/stencils/apache/manifest.json
+++ b/tests/test_templatepack/stencils/apache/manifest.json
@@ -19,7 +19,11 @@
         "templates/default/apache/apache2.conf.erb": "templates/default/apache2.conf.erb",
         "templates/default/apache/mpm_event.conf.erb": "templates/default/mpm_event.conf.erb",
         "templates/default/apache/ports.conf.erb": "templates/default/ports.conf.erb",
-        "test/integration/default/serverspec/<NAME>_spec.rb": "test/integration/default/serverspec/apache_spec.rb"
+        "test/integration/default/serverspec/<NAME>_spec.rb": "test/integration/default/serverspec/apache_spec.rb",
+        "multiple_stencils.txt": "multiple_stencils.txt"
+      },
+      "partials": {
+        ".kitchen.yml": ".kitchen.yml.jinja2"
       },
       "options": {
       }

--- a/tests/test_templatepack/stencils/apache/multiple_stencils.txt
+++ b/tests/test_templatepack/stencils/apache/multiple_stencils.txt
@@ -1,0 +1,1 @@
+apache stencil

--- a/tests/test_templatepack/stencils/base/files/multiple_stencils.txt
+++ b/tests/test_templatepack/stencils/base/files/multiple_stencils.txt
@@ -1,0 +1,1 @@
+base stencil

--- a/tests/test_templatepack/stencils/base/manifest.json
+++ b/tests/test_templatepack/stencils/base/manifest.json
@@ -23,7 +23,8 @@
         "test/unit/spec/spec_helper.rb": "test/unit/spec/spec_helper.rb",
         "test/integration/encrypted_data_bag_secret": "test/integration/encrypted_data_bag_secret",
         "test/integration/default/serverspec/spec_helper.rb": "test/integration/default/serverspec/spec_helper.rb",
-        "test/integration/default/serverspec/default_spec.rb": "test/integration/default/serverspec/default_spec.rb"
+        "test/integration/default/serverspec/default_spec.rb": "test/integration/default/serverspec/default_spec.rb",
+        "multiple_stencils.txt": "files/multiple_stencils.txt"
       },
       "options": {
       }


### PR DESCRIPTION
- Use the `written_files` array to keep track of files written during the current execution of fastfood. Allow later stencils to overwrite templates written by earlier stencils, and emit a warning. Add a test to be sure this works correctly. Fixes #67.

- Introduce partials, which work exactly like `"files": {}` in stencils, except they append to an existing file. Like files, they will only append to files written during the current execution of fastfood. Once written, they will not continually append. Add a test to be sure this works correctly. Fixes #73. Fixes #26.

- Factor out the following logic into easier to read, separate, private class methods:
  - Determine the stencil to use or use the default stencil, for a stencil set
  - Building the template variable map for a stencil
  - Rendering the actual template contents for a stencil